### PR TITLE
Enhance edge case handling and improve readability in `parameters/parser/ParamsParser.go`

### DIFF
--- a/parameters/parser/ParamsParser.go
+++ b/parameters/parser/ParamsParser.go
@@ -315,6 +315,10 @@ func parseVersionedGlobalParams(p *VersionedGlobalParams) (*ParsedVersionedGloba
 // are applicable at the given BTC btcHeight. If there in no versioned global params
 // applicable at the given btcHeight, it will return nil.
 func (g *ParsedGlobalParams) GetVersionedGlobalParamsByHeight(btcHeight uint64) *ParsedVersionedGlobalParams {
+	// Check if the Versions slice is empty
+	if len(g.Versions) == 0 {
+		return nil
+	}
 	// Iterate the list in reverse (i.e. decreasing ActivationHeight)
 	// and identify the first element that has an activation height below
 	// the specified BTC height.
@@ -328,10 +332,10 @@ func (g *ParsedGlobalParams) GetVersionedGlobalParamsByHeight(btcHeight uint64) 
 }
 
 // FindLastStakingCap finds the last staking cap that is not zero
-// it returns zero if not non-zero value is found
+// it returns zero if no non-zero value is found
 func FindLastStakingCap(prevVersions []*VersionedGlobalParams) uint64 {
 	numPrevVersions := len(prevVersions)
-	if len(prevVersions) == 0 {
+	if numPrevVersions == 0 {
 		return 0
 	}
 


### PR DESCRIPTION
- Added a check in GetVersionedGlobalParamsByHeight to return nil when Versions slice is empty, optimizing the function for edge cases.
- Fixed a typo in the comment for FindLastStakingCap function to clarify its return behavior.
- Minor refactoring in FindLastStakingCap to reduce redundant length checks.