### PR TITLE
docs: `bbn-test-5` landing page

### DIFF
--- a/bbn-test-5/README.md
+++ b/bbn-test-5/README.md
@@ -1,0 +1,31 @@
+# Babylon Networks
+
+Welcome to the network page for the Babylon Phase-2 testnet (`bbn-test-5`).
+This is your central hub 
+for network participation information, whether you're running a node, 
+operating as a validator, providing finality services, or participating 
+in the covenant committee.
+
+## Network Parameters
+
+<!-- TODO: sync with devops on the things we should add here.
+Off the top of my head:
+* Chain ID
+* Genesis file location
+* Seed nodes
+* RPC nodes
+* Snapshot
+
+We can fully link to our partners here.
+-->
+...
+
+## Network Participants
+
+There are four types of participants in the Babylon network.
+Please see the setup and configuration guides below:
+
+- [Babylon Node Operators](babylon-node/README.md)
+- [Validators](babylon-validators/README.md)
+- [Finality Providers](https://github.com/babylonlabs-io/finality-providers)
+- [Covenant Committee](covenant-committee/README.md)

--- a/bbn-test-5/README.md
+++ b/bbn-test-5/README.md
@@ -1,4 +1,4 @@
-# Babylon Networks
+# Babylon testnet-5 Network
 
 Welcome to the network page for the Babylon Phase-2 testnet (`bbn-test-5`).
 This is your central hub 
@@ -6,9 +6,9 @@ for network participation information, whether you're running a node,
 operating as a validator, providing finality services, or participating 
 in the covenant committee.
 
+<!-- TODO: sync with devops on the things we should add here.
 ## Network Parameters
 
-<!-- TODO: sync with devops on the things we should add here.
 Off the top of my head:
 * Chain ID
 * Genesis file location
@@ -18,8 +18,9 @@ Off the top of my head:
 
 We can fully link to our partners here.
 -->
-...
 
+<!-- TODO: Uncover the following sections
+with each PR that is getting merged
 ## Network Participants
 
 There are four types of participants in the Babylon network.
@@ -29,3 +30,4 @@ Please see the setup and configuration guides below:
 - [Validators](babylon-validators/README.md)
 - [Finality Providers](https://github.com/babylonlabs-io/finality-providers)
 - [Covenant Committee](covenant-committee/README.md)
+-->


### PR DESCRIPTION
## Summary

As of now there is no landing page for the latest testnet. This PR will cover this and direct people to the necessary places