### PR TITLE
Fix: Update finality provider repository URL in README

### DIFF
--- a/bbn-test-5/finality-providers/README.md
+++ b/bbn-test-5/finality-providers/README.md
@@ -26,7 +26,7 @@ go version
 Subsequently clone the finality provider [repository](https://github.com/babylonlabs-io/finality-provider).
 
 ```shell
-git clone https://github.com/babylonchain/finality-provider.git
+git clone https://github.com/babylonlabs-io/finality-provider.git
 ```
 
 Once the `babylon` repository is downloaded then checkout the corresponding tag for `bbn-testnet-5`.


### PR DESCRIPTION
This PR updates the repository URL for the finality provider in the README.md file to the correct Babylon Labs GitHub repository.

Changed
from https://github.com/babylonchain/finality-provider.git to https://github.com/babylonlabs-io/finality-provider.git