### PR TITLE
Fix/err

### DIFF
--- a/bbn-1/finality-providers/registry/OrangeBob.json
+++ b/bbn-1/finality-providers/registry/OrangeBob.json
@@ -4,7 +4,7 @@
     "identity": "3A4D5732E464C7BD",
     "website": "https://val.orangebob.buzz",
     "security_contact": "erhamreza3@gmail.com",
-    "details": "High uptime & Low commision"
+    "details": "High uptime & Low commission"
   },
   "eots_pk": "2c961b25702189ebeac186b087a122998be2cdebb2845f70477d061de2123f2d",
   "commission": "0.05"

--- a/parameters/parser/ParamsParser_test.go
+++ b/parameters/parser/ParamsParser_test.go
@@ -268,7 +268,7 @@ func TestFailGlobalParamsValidation(t *testing.T) {
 	_, err = parser.NewParsedGlobalParamsFromFile(fileName)
 	assert.Equal(t, "invalid params with version 0: covenant quorum 6 cannot be more than the amount of covenants 5", err.Error())
 
-	// test invalid convenant pks
+	// test invalid covenant pks
 	deepCopy(&defaultGlobalParams, &clonedParams)
 	clonedParams.Versions[0].CovenantPks = []string{
 		"04ffeaec52a9b407b355ef6967a7ffc15fd6c3fe07de2844d61550475e7a5233e5",


### PR DESCRIPTION
# Fix: Corrected typos in JSON and source files

## Changes
1. **File**: `bbn-1/finality-providers/registry/OrangeBob.json`
   - Fixed a typo by changing "commision" to "commission" (Line 7).

2. **File**: `parameters/parser/ParamsParser_test.go`
   - Fixed a typo by changing "convenant" to "covenant" (Line 271).

## Purpose
- Improved accuracy in both JSON and source files by fixing typographical errors.
- Enhanced clarity and professionalism across the project.
