### PR TITLE
Change clone link to https instead of ssh.

### DIFF
--- a/bbn-test-5/babylon-node/README.md
+++ b/bbn-test-5/babylon-node/README.md
@@ -25,7 +25,7 @@ Next, clone the Babylon codebase
 and install the Babylon binary:
 
 ```shell
-git clone git@github.com:babylonlabs-io/babylon.git
+git clone https://github.com/babylonlabs-io/babylon.git
 cd babylon
 # tag corresponds to the version of the software
 # you want to install -- depends on which


### PR DESCRIPTION
Cloning via ssh requires you to authenticate first which is not needed.