### PR TITLE
Fix: Corrected CLI flag for empty BLS password

### DIFF
--- a/bbn-1/babylon-node/README.md
+++ b/bbn-1/babylon-node/README.md
@@ -91,7 +91,7 @@ Parameters:
 >   error will be raised):
 >   * **Environment Variable**: `BABYLON_BLS_PASSWORD` is set.
 >   * **CLI flags**: One of the following CLI options has been set:
->     * `--no-bls-key` is a flag that if set designates that an empty BLS
+>     * `--no-bls-password` is a flag that if set designates that an empty BLS
 >       password should be used.
 >     * `--bls-password-file=<path>` allows to specify a file location that
 >       contains the plaintext BLS password.


### PR DESCRIPTION
The CLI flag to indicate an empty BLS password was incorrectly documented as `--no-bls-key`.

This commit corrects the documentation to reflect the actual flag, which is `--no-bls-password`.