### PR TITLE
Docs: Updated and refined node installation guide

### DIFF
--- a/bbn-1/README.md
+++ b/bbn-1/README.md
@@ -26,6 +26,7 @@ A snapshot including state up to height `226` can be retrieved from
 To boot a node with this snapshot, Babylon version `v1.0.1` should be used
 ([reference](https://github.com/babylonlabs-io/babylon/releases/tag/v1.0.1)).
 
+Pruned ITRocket snapshot with commands to install can be retrieved [here](https://itrocket.net/services/mainnet/babylon/#snap).
 
 Some additional network snapshot sources are also listed:
 


### PR DESCRIPTION
### Updates for the Node Installation guide:
- Added variables for `.bash_profile` in the beginning of installation for more convenience;
- Added `go` installation commands;
- All necessary changes in `client.toml`, `config.toml`, and `app.toml` are now made with commands, not manually;
- Optional custom ports configuration is added;
- Node start now has 2 options: from CLI or with a service file;
- Added **one-command** [**autoinstallation**](https://itrocket.net/services/mainnet/babylon/installation/#auto-installation) developed by us. It installs all the necessary dependencies, installs the binary and configures the node (edits configuration files, downloads genesis and addrbook, sets seeds and peers), downloads a snapshot, and runs the node with a service file.

Also, we've added ITRocket pruned snapshot to the list. 