### PR TITLE
chore: add v4.4 upgrade info for bbn-1 and bbn-test-6

### DIFF
--- a/bbn-1/network-artifacts/upgrades/README.md
+++ b/bbn-1/network-artifacts/upgrades/README.md
@@ -13,3 +13,4 @@ You can find a list of the Software Upgrades listed in chronological order here:
 - The [v4.1](./v4.1/README.md) upgrade was performed at Babylon block `1987027`
 - The [v4.2](./v4.2/README.md) upgrade was performed at Babylon block `2072934`
 - The [v4.3](./v4.3/README.md) upgrade was performed at Babylon block `3371450`
+- The [v4.4](./v4.4/README.md) upgrade is scheduled to be performed at Babylon block `4171630`

--- a/bbn-1/network-artifacts/upgrades/v4.4/README.md
+++ b/bbn-1/network-artifacts/upgrades/v4.4/README.md
@@ -1,0 +1,30 @@
+# `v4.4` Software Upgrade
+
+## Upgrade overview
+
+- **Upgrade version**: `v4.4.0`
+- **Upgrade height**: `4171630`
+
+## Upgrade process
+
+### Prepare the upgrade binary
+
+Obtain the `v4.4.0` binary. You can achieve this in multiple ways:
+  - Download the binary from the [releases
+    page](https://github.com/babylonlabs-io/babylon/releases/tag/v4.4.0)
+  - Build the binary on your machine
+    ```shell
+    git checkout v4.4.0
+    make install
+    ```
+  - If you're working with Docker images, you can pull the pre-built Docker image:
+    ```shell
+    docker pull babylonlabs/babylond:v4.4.0
+    ```
+
+### Perform the upgrade
+
+Perform the following steps to upgrade your Babylon node:
+* Stop your Babylon node
+* Swap your babylon binary with the prepared `v4.4.0` binary
+* Start your Babylon node

--- a/bbn-1/network-artifacts/upgrades/v4.4/upgrade_binaries.json
+++ b/bbn-1/network-artifacts/upgrades/v4.4/upgrade_binaries.json
@@ -1,0 +1,6 @@
+{
+    "binaries": {
+        "linux/amd64": "https://github.com/babylonlabs-io/babylon/releases/download/v4.4.0/babylon-4.4.0-linux-amd64",
+        "linux/arm64": "https://github.com/babylonlabs-io/babylon/releases/download/v4.4.0/babylon-4.4.0-linux-arm64"
+    }
+}

--- a/bbn-test-6/babylon-node/upgrades/README.md
+++ b/bbn-test-6/babylon-node/upgrades/README.md
@@ -14,3 +14,4 @@ You can find a list of the Software Upgrades listed in chronological order here:
 - The [v4.1](./v4.1/README.md) upgrade was performed at Babylon block `384300`
 - The [v4.2](./v4.2/README.md) upgrade was performed at Babylon block `469778`
 - The [v4.3](./v4.3/README.md) upgrade was performed at Babylon block `1781710`
+- The [v4.4](./v4.4/README.md) upgrade is scheduled to be performed at Babylon block `2613009`

--- a/bbn-test-6/babylon-node/upgrades/v4.4/README.md
+++ b/bbn-test-6/babylon-node/upgrades/v4.4/README.md
@@ -1,0 +1,30 @@
+# `v4.4` Software Upgrade
+
+## Upgrade overview
+
+- **Upgrade version**: `v4.4.0`
+- **Upgrade height**: `2613009`
+
+## Upgrade process
+
+### Prepare the upgrade binary
+
+Obtain the `v4.4.0` binary. You can achieve this in multiple ways:
+  - Download the binary from the [releases
+    page](https://github.com/babylonlabs-io/babylon/releases/tag/v4.4.0)
+  - Build the binary on your machine
+    ```shell
+    git checkout v4.4.0
+    BABYLON_BUILD_OPTIONS="testnet" make install
+    ```
+  - If you're working with Docker images, you can pull the pre-built Docker image:
+    ```shell
+    docker pull babylonlabs/babylond:v4.4.0-testnet
+    ```
+
+### Perform the upgrade
+
+Perform the following steps to upgrade your Babylon node:
+* Stop your Babylon node
+* Swap your babylon binary with the prepared `v4.4.0` binary
+* Start your Babylon node

--- a/bbn-test-6/babylon-node/upgrades/v4.4/upgrade_binaries.json
+++ b/bbn-test-6/babylon-node/upgrades/v4.4/upgrade_binaries.json
@@ -1,0 +1,6 @@
+{
+    "binaries": {
+        "linux/amd64": "https://github.com/babylonlabs-io/babylon/releases/download/v4.4.0/babylon-testnet-4.4.0-linux-amd64",
+        "linux/arm64": "https://github.com/babylonlabs-io/babylon/releases/download/v4.4.0/babylon-testnet-4.4.0-linux-arm64"
+    }
+}


### PR DESCRIPTION
## Summary

Adds the `v4.4` software upgrade info for both networks, mirroring each network's existing `v4.3` entry:

- **bbn-1 (mainnet)** — `network-artifacts/upgrades/v4.4/`, upgrade height **`4171630`**, `v4.4.0` (non-testnet binaries).
- **bbn-test-6 (testnet)** — `babylon-node/upgrades/v4.4/`, upgrade height **`2613009`**, `v4.4.0-testnet` binaries.

Each adds `README.md` + `upgrade_binaries.json` and an entry in the network's top-level upgrades `README.md`.

## Note

The `v4.4.0` release/tag is not cut yet, so the binary download URLs and docker tags referenced here will resolve once the release is published. `release/v4.4.x` is on cosmos-sdk `v0.53.8`.

Please double-check the upgrade heights before merge.
