### PR TITLE
docs: add OpenChainBench RPC latency benchmark link

### DIFF
--- a/bbn-1/README.md
+++ b/bbn-1/README.md
@@ -52,6 +52,8 @@ Archive:
 - https://babylon-archive.nodes.guru/rpc
 - https://babylon-archive-rpc.polkachu.com
 
+See also: [OpenChainBench Babylon RPC benchmark](https://openchainbench.com/bench/babylon-rpc) — live latency comparison of free public endpoints (PublicNode, Polkachu, LavenderFive), measured every 60s from 3 regions.
+
 ##### LCD (node API)
 
 Pruned:


### PR DESCRIPTION
## What this adds

A single line under the RPC endpoints section in `bbn-1/README.md` linking to the [OpenChainBench Babylon RPC benchmark](https://openchainbench.com/bench/babylon-rpc).

## Why it is useful

OpenChainBench continuously measures Tendermint `/status` latency for three free, keyless Babylon RPC endpoints:

- PublicNode
- Polkachu
- LavenderFive

Measurements run every 60 seconds from 3 geographic regions (EU, US, Asia). Results are public and require no API key.

Developers syncing a node or building tooling against Babylon mainnet can use the benchmark to pick the lowest-latency endpoint for their region instead of guessing. The page shows p50/p95 latency per provider per region with historical charts.

The link is placed right below the existing RPC listing so it is easy to discover without disrupting the current structure.