### PR TITLE
docs: add OpenChainBench RPC latency benchmark link

### DIFF
--- a/bbn-1/README.md
+++ b/bbn-1/README.md
@@ -52,6 +52,8 @@ Archive:
 - https://babylon-archive.nodes.guru/rpc
 - https://babylon-archive-rpc.polkachu.com
 
+See also: [OpenChainBench Babylon RPC benchmark](https://openchainbench.com/benchmarks/babylon-rpc) — live latency data for free public endpoints (PublicNode, Polkachu, LavenderFive), measured every 60s from 3 regions.
+
 ##### LCD (node API)
 
 Pruned:


### PR DESCRIPTION
OpenChainBench measures Tendermint `/status` latency for 3 free keyless Babylon RPC endpoints (PublicNode, Polkachu, LavenderFive) every 60 seconds from 3 geographic regions. The benchmark page at https://openchainbench.com/benchmarks/babylon-rpc gives node operators and developers a live view of public endpoint performance and reliability. Adding this reference in the RPC section makes it easy to find real latency data alongside the endpoint list.